### PR TITLE
Some improvements and bug fix

### DIFF
--- a/apps/common/application_lock.h
+++ b/apps/common/application_lock.h
@@ -27,7 +27,9 @@
 
 #include <string>
 #include <stdexcept>
-#include <iostream>
+#include <filesystem>
+
+namespace fs = std::filesystem;
 
 namespace elastos {
 namespace carrier {
@@ -38,6 +40,12 @@ public:
     ~ApplicationLock() { release(); };
 
     int acquire(const std::string& filename) {
+        // Make sure the existence of the parent directory
+        fs::path lockPath = filename;
+        auto parent = lockPath.parent_path();
+        if (!fs::exists(parent))
+            fs::create_directories(parent);
+
         this->filename = filename;
         fd = open(filename.c_str(), O_RDWR | O_CREAT, 0666);
         if (fd < 0)

--- a/apps/common/coredump.h
+++ b/apps/common/coredump.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 - 2023 trinity-tech.io
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#ifdef HAVE_SYS_RESOURCE_H
+
+#include <sys/resource.h>
+
+static inline int sys_coredump_set(bool enable)
+{
+    const struct rlimit rlim = {
+        enable ? RLIM_INFINITY : 0,
+        enable ? RLIM_INFINITY : 0
+    };
+
+    return setrlimit(RLIMIT_CORE, &rlim);
+}
+#else
+#define sys_coredump_set(enable) (void)0
+#endif

--- a/apps/launcher/launcher.cc
+++ b/apps/launcher/launcher.cc
@@ -39,6 +39,7 @@
 #include <carrier.h>
 #include "../../src/core/constants.h"
 #include <application_lock.h>
+#include <coredump.h>
 
 using namespace elastos::carrier;
 
@@ -228,6 +229,8 @@ static void setupSignals()
 
 int main(int argc, char *argv[])
 {
+    sys_coredump_set(true);
+
     auto params = parseArgs(argc, argv);
     if (params.help) {
         print_usage();

--- a/apps/shell/main.cc
+++ b/apps/shell/main.cc
@@ -24,11 +24,9 @@
 #include <csignal>
 #include <cctype>
 
-#ifdef HAVE_SYS_RESOURCE_H
-#include <sys/resource.h>
-#endif
-
 #include <editline/readline.h>
+
+#include <coredump.h>
 
 #include "shell.h"
 #include "id_command.h"
@@ -47,18 +45,6 @@
 #include "exit_command.h"
 
 static const std::string prompt = "Carrier $";
-
-#ifdef HAVE_SYS_RESOURCE_H
-int sys_coredump_set(bool enable)
-{
-    const struct rlimit rlim = {
-        enable ? RLIM_INFINITY : 0,
-        enable ? RLIM_INFINITY : 0
-    };
-
-    return setrlimit(RLIMIT_CORE, &rlim);
-}
-#endif
 
 char *trim(char *str)
 {

--- a/src/addons/activeproxy/connection.h
+++ b/src/addons/activeproxy/connection.h
@@ -119,7 +119,7 @@ protected:
     void onDataRequest(const uint8_t* packet, size_t size) noexcept;
 
     void openUpstream() noexcept;
-    void closeUpstream() noexcept;
+    void closeUpstream(bool force = false) noexcept;
     void startReadUpstream() noexcept;
 
     void onAuthorized(const CryptoBox::PublicKey& serverPk, const CryptoBox::Nonce& nonce, uint16_t port) noexcept {

--- a/src/core/dht.cc
+++ b/src/core/dht.cc
@@ -91,7 +91,7 @@ void DHT::bootstrap() {
 
         auto call = std::make_shared<RPCCall>(this, node, q);
         call->addStateChangeHandler([&](RPCCall* call, RPCCall::State previous, RPCCall::State current) {
-            log->info("RPCCall::OnStateChange for FindNodeRequest message invoked .....");
+            log->debug("RPCCall::OnStateChange for FindNodeRequest message invoked .....");
             if (current == RPCCall::State::RESPONDED || current == RPCCall::State::ERROR
                     || current == RPCCall::State::TIMEOUT) {
                 auto r = std::dynamic_pointer_cast<FindNodeResponse>(call->getResponse());
@@ -151,7 +151,7 @@ void DHT::updateBootstrapNodes() {
 
         auto call = std::make_shared<RPCCall>(this, node, q);
         call->addStateChangeHandler([=](RPCCall* call, RPCCall::State previous, RPCCall::State current) {
-            log->info("RPCCall::OnStateChange for FindNodeRequest message invoked .....");
+            log->debug("RPCCall::OnStateChange for FindNodeRequest message invoked .....");
             if (current == RPCCall::State::RESPONDED || current == RPCCall::State::ERROR
                     || current == RPCCall::State::TIMEOUT) {
                 auto r = std::dynamic_pointer_cast<FindNodeResponse>(call->getResponse());

--- a/src/core/rpcserver.cc
+++ b/src/core/rpcserver.cc
@@ -206,11 +206,11 @@ int RPCServer::sendData(Sp<Message>& msg) {
         msg->setName(txidNames[msg->getTxid()]);
         if (filterMessage(msg->name)) {
             auto af = msg->getRemoteAddress().family();
-            log->info("\n\n-- Sent: {} bytes --\nLocal: {}\nTo: {}\n{}\n-- ** --\n",
+            log->debug("\n\n-- Sent: {} bytes --\nLocal: {}\nTo: {}\n{}\n-- ** --\n",
                     ret, getAddress(af).toString(), msg->getRemoteAddress().toString(), static_cast<std::string>(*msg));
         }
 #else
-        log->info("Sent {}/{} to {}: [{}] {}", msg->getMethodString(), msg->getTypeString(),
+        log->debug("Sent {}/{} to {}: [{}] {}", msg->getMethodString(), msg->getTypeString(),
                 msg->getRemoteAddress().toString(), buffer.size(), static_cast<std::string>(*msg));
 #endif
         return 0;
@@ -539,11 +539,11 @@ void RPCServer::handlePacket(const uint8_t *buf, size_t buflen, const SocketAddr
 #ifdef MSG_PRINT_DETAIL
     msg->setName(txidNames[msg->getTxid()]);
     if (filterMessage(msg->name)) {
-        log->info("\n\n-- Received: {} bytes -- \nLocal: {}\nFrom: {}\n{}\n-- ** --\n",
+        log->debug("\n\n-- Received: {} bytes -- \nLocal: {}\nFrom: {}\n{}\n-- ** --\n",
                   buflen,  getAddress(from.family()).toString(), from.toString(), static_cast<std::string>(*msg));
     }
 #else
-    log->info("Received {}/{} from {}: [{}] {}", msg->getMethodString(), msg->getTypeString(),
+    log->debug("Received {}/{} from {}: [{}] {}", msg->getMethodString(), msg->getTypeString(),
             from.toString(), buflen, static_cast<std::string>(*msg));
 #endif
 


### PR DESCRIPTION
- Make sys_coredump_set as app common header, enable coredump for launcher
- Fixed the application lock error when the parent directory of the lock file not exists
- Decrease the log verbose level for in/out RPC messages
- Fixed double close error when the connection closed exceptionally