### PR TITLE
Remove extra and useless return branch in checking funciton 'isBogonA…

### DIFF
--- a/src/core/task/lookup_task.cc
+++ b/src/core/task/lookup_task.cc
@@ -84,7 +84,6 @@ bool LookupTask::isBogonAddress(const SocketAddress &addr) const {
 #else
     return addr.isBogon();
 #endif
-    return false;
 }
 
 } // namespace carrier


### PR DESCRIPTION
…ddress'